### PR TITLE
refactor: Remove "Sonsoles Stays" branding

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/png" href="/src/assets/arg.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>ARG TRIP - Sonsoles Stays</title>
+    <title>ARG TRIP</title>
 
     <!-- Google Fonts -->
     <link

--- a/src/components/common/CreditCardWarning.jsx
+++ b/src/components/common/CreditCardWarning.jsx
@@ -8,8 +8,8 @@ const CreditCardWarning = ({ paymentSchedule, exchangeRate }) => {
         <h3>Important</h3>
         <ul>
           <li>
-            Credit card payments are to be denominated in EUR, as Sonsoles Stays
-            is a business operating from 🇪🇸 Spain.
+            Credit card payments are to be denominated in EUR, as we are
+            a business operating from 🇪🇸 Spain.
           </li>
           <li>
             Bank transfers & crypto payments are denominated and handled in USD.

--- a/src/components/layout/Header.jsx
+++ b/src/components/layout/Header.jsx
@@ -6,7 +6,6 @@ const Header = () => {
     <div className="container">
       <header className="header">
         <div className="header-content">
-          <div className="superset">by Sonsoles Stays</div>
           <h1>
             <i className="fas fa-mountain"></i> Argentina Trip
           </h1>


### PR DESCRIPTION
This commit removes the "by Sonsoles Stays" text from the header, page title, and a credit card warning message, following the user's request.

Changes include:
- Removing the "by Sonsoles Stays" line from the Header component.
- Updating the page title in index.html to "ARG TRIP".
- Replacing "as Sonsoles Stays" with "as we are" in the CreditCardWarning component for a more generic message.